### PR TITLE
Fix footer license link font size

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -72,6 +72,7 @@
   }
 
   #licenseInfo {
+    font-size: 0.75rem;
     color: var(--text-color-footer);
     text-decoration: none;
     transition: 0.4s all;


### PR DESCRIPTION
## Summary
- The footer's license link (`#licenseInfo`) was picking up the global `a { font-size: 1.2rem }` rule from `main.css` instead of matching the surrounding `.text-caption` copyright text (~0.75rem), making it look noticeably larger/inconsistent next to "© 2024-2026 Ashley Merienne".
- Scoped `#licenseInfo` to `font-size: 0.75rem` so it visually matches the rest of the footer text.

Fixes #5

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed the compiled CSS bundle contains `#licenseInfo{font-size:.75rem;...}`