### PR TITLE
Make footer bigger: larger icons, text, and footer height

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -5,19 +5,19 @@
       :key="item.title"
       :href="item.href"
       :title="item.title"
-      class="d-inline-block mx-2 social-link"
+      class="d-inline-block mx-3 social-link"
       rel="noopener noreferrer"
       target="_blank"
     >
       <v-icon
         :icon="item.icon"
-        :size="item.icon === '$vuetify' ? 24 : 16"
+        :size="item.icon === '$vuetify' ? 36 : 28"
       />
     </a>
 
     <div
-      class="text-caption"
-      style="position: absolute; right: 16px; color: var(--text-color-footer);"
+      class="footer-copyright"
+      style="color: var(--text-color-footer);"
     >
       &copy; 2024-{{ (new Date()).getFullYear() }} <span class="d-none d-sm-inline-block">Ashley Merienne</span>
       —
@@ -71,8 +71,13 @@
       color: var(--bg-color-main);
   }
 
+  .footer-copyright {
+    margin-left: auto;
+    font-size: 1rem;
+  }
+
   #licenseInfo {
-    font-size: 0.75rem;
+    font-size: 1rem;
     color: var(--text-color-footer);
     text-decoration: none;
     transition: 0.4s all;

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -72,6 +72,7 @@
   }
 
   #licenseInfo {
+    font-size: 0.75rem;
     color: var(--text-color-footer);
     text-decoration: none;
     transition: 0.4s all;

--- a/src/styles/vars.css
+++ b/src/styles/vars.css
@@ -13,7 +13,7 @@
     --text-color-footer: #aaaaaa;
 
     --header-height: 80px;
-    --footer-height: 60px;
+    --footer-height: 96px;
 
     --padding: 10px;
     --main-padding: 10%;


### PR DESCRIPTION
## Summary
- Increased `--footer-height` from 60px to 96px.
- Enlarged the social icons (36px for the Vuetify icon, 28px for the others, up from 24/16).
- Bumped the copyright/license text from Vuetify's `text-caption` (0.75rem) up to 1rem.
- Replaced the copyright block's `position: absolute; right: 16px` with `margin-left: auto`, so it participates in the `v-footer`'s flex row (Vuetify's `.v-footer` is `display: flex; align-items: center;`) instead of floating independently — this keeps it vertically centered and prevents it from overlapping the now-larger icons, including at narrow/mobile widths.

Note: this branch is stacked on #7 (the license-link font-size fix), so its diff includes that one-line change until #7 merges — it'll drop out automatically once #7 lands.

Fixes #6

## Test plan
- [x] `npm run build` succeeds
- [x] Confirmed compiled CSS bundle reflects the new footer height, icon sizes, and `.footer-copyright { margin-left: auto; font-size: 1rem }`
- [ ] Visual check in a browser (headless Chromium isn't available in this sandbox to screenshot, but the CSS cascade/flex-layout behavior was verified directly against Vuetify's `.v-footer` styles)