### PR TITLE
Rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,40 @@
 # sillyash's blog
 
-## For random trivia, interesting hobbies, niche pieces of culture, and see my projects !
+For random trivia, interesting hobbies, niche pieces of culture, and my projects.
 
-Hosted by GitHub Pages on [here](https://sillyash.github.io)
+Live at [sillyash.com](https://sillyash.com), hosted on GitHub Pages.
 
 ## Tools
 
-I used Vuetify for the code and file structure, and custom theming.
+Built with [Vue 3](https://vuejs.org/) and [Vuetify 3](https://vuetifyjs.com/), scaffolded via Vuetify's Vite template:
 
-## Build
+- [Vite](https://vitejs.dev/) — build tool / dev server
+- [vue-router](https://router.vuejs.org/) with file-based routes (`unplugin-vue-router`) and layouts (`vite-plugin-vue-layouts`)
+- [Pinia](https://pinia.vuejs.org/) for state
+- [ESLint](https://eslint.org/) (`eslint-config-vuetify`) for linting
 
-```bash
-npm run build
+## Project structure
+
+```
+src/
+├── components/   # AppHeader, AppFooter (auto-imported)
+├── layouts/      # default.vue wraps every page with header/footer
+├── pages/        # one file = one route (index, AboutMe, Projects, ContactMe)
+├── plugins/      # vuetify/router/pinia setup, glossary auto-linker
+├── stores/       # Pinia stores
+└── styles/       # global CSS, custom-property based color/size theme
 ```
 
-## Deploy
+## Development
 
 ```bash
-npm run deploy
+npm install
+npm run dev       # start the dev server
+npm run build     # production build to dist/
+npm run preview   # preview a production build locally
+npm run lint      # eslint --fix
 ```
 
+## CI/CD
+
+On every push/PR to `main`, [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml) installs, lints, builds, and runs `npm audit`. On push to `main`, it also deploys the build to GitHub Pages via `actions/deploy-pages` — no manual deploy step needed.


### PR DESCRIPTION
## Summary
- Replaced the stale README (referenced a now-removed `npm run deploy` script) with one that matches the current stack: Vue 3 + Vuetify 3 via Vite, file-based routing/layouts, Pinia, ESLint.
- Added a project structure overview and documented the actual dev scripts (`dev`, `build`, `preview`, `lint`).
- Documented the CI/CD pipeline (lint/build/audit on PR+push, auto-deploy to Pages on push to `main`).

## Test plan
- [x] Read through for accuracy against current `package.json` scripts and `.github/workflows/ci-cd.yml`